### PR TITLE
refactor: remove commented interface function from shader files

### DIFF
--- a/src/components/galaxy/stars/sun/sunFragmentShader.glsl
+++ b/src/components/galaxy/stars/sun/sunFragmentShader.glsl
@@ -196,7 +196,6 @@ float fbm4D(vec3 pos, float w, float detail, float roughness, float lacunarity) 
   return total / maxValue;
 }
 
-// 然后你自己包装一个接口函数
 float noiseTextureFBM(
   vec3 coord,
   float w,

--- a/src/components/galaxy/stars/sun/sunHaloFragmentShader.glsl
+++ b/src/components/galaxy/stars/sun/sunHaloFragmentShader.glsl
@@ -158,7 +158,6 @@ float fbm4D(vec3 pos, float w, float detail, float roughness, float lacunarity) 
   return total / maxValue;
 }
 
-// 然后你自己包装一个接口函数
 float noiseTextureFBM(
   vec3 coord,
   float w,

--- a/src/shaders/texture.glsl
+++ b/src/shaders/texture.glsl
@@ -161,7 +161,6 @@ float fbm4D(vec3 pos, float w, float detail, float roughness, float lacunarity) 
   return total / maxValue;
 }
 
-// 然后你自己包装一个接口函数
 float noiseTextureFBM(
   vec3 coord,
   float w,


### PR DESCRIPTION
- Removed unnecessary commented lines indicating the wrapping of an interface function in sunFragmentShader.glsl, sunHaloFragmentShader.glsl, and texture.glsl for cleaner code.